### PR TITLE
Added short topic desc

### DIFF
--- a/src/orchid/resources/posts/meetups/2022-11-20-meetup-1.md
+++ b/src/orchid/resources/posts/meetups/2022-11-20-meetup-1.md
@@ -6,4 +6,6 @@ tags:
     - meetup
 ---
 
-Agenda to be announced soon
+*Agenda:*
+- Static code analysis for Kotlin: A Guiding Star - Vladislav Ermolin  
+Community has created multiple static code analysis tools for Kotlin. We'll discuss what makes them unique, and, what's more important, what unites them all. With the use of this knowledge, creating custom rule for any of those tools becomes an abstract task, which we'll observe on example.


### PR DESCRIPTION
At first I wanted to make an overview. But everything was told back in 2018: https://www.youtube.com/watch?v=LT6m5_LO2DQ
Instead, I'll compare KtLint, Detekt, Android Lint (the only one of them, which uses UAST - I'll use it as an example of a higher level of abstraction), exaplain the diff, the similarity and show an example of the same rule being implemented with all 3 tools.
The overall goal is to demonstrate that they all are kinda the same, thanks to PSI and UAST trees.